### PR TITLE
fix: add missing slash in hashtag URL

### DIFF
--- a/crates/apub/src/objects/note.rs
+++ b/crates/apub/src/objects/note.rs
@@ -142,7 +142,7 @@ impl Note {
                         .map(|tag| {
                             Tag::Hashtag(Hashtag::new(
                                 Url::parse(&format!(
-                                    "https://{}/t{}",
+                                    "https://{}/t/{}",
                                     data.domain(),
                                     urlencoding::encode(&tag),
                                 ))


### PR DESCRIPTION
In this file, hashtag URLs were being generated as both `/t/{hashtag}` and `/t{hashtag}`. This commit changes both instances to be `/t/{hashtag}`.