### PR TITLE
fix(apub): set note visibility to public

### DIFF
--- a/crates/apub/src/objects/note.rs
+++ b/crates/apub/src/objects/note.rs
@@ -132,8 +132,11 @@ impl Note {
             published: published.unwrap_or_else(hatsu_utils::date::now),
             updated,
             attributed_to: actor.id().into(),
-            to: vec![Url::parse(&format!("{}/followers", actor.id()))?],
-            cc: vec![public()],
+            // to: vec![Url::parse(&format!("{}/followers", actor.id()))?],
+            // cc: vec![public()],
+            to: vec![public()],
+            // Leaving a CC here to retain compatibility, figured I should CC followers instead of public twice
+            cc: vec![Url::parse(&format!("{}/followers", actor.id()))?],
             content,
             source: Some(serde_json::to_value(NoteSource::new(source))?),
             tag: json.tags.map_or_else(Vec::new, |tags| {


### PR DESCRIPTION
I think that the default behavior, unlisted posts, is counter-intuitive and should instead be public posts by default. 

Ideally, this should be configurable through an option on the individual post or the feed level (that's why I'm leaving this as a draft).

 I was thinking I could add it to the existing extension on the JSON Feed, and then work on making an XML namespace to hold options for RSS/Atom.

I'm not sure whether this would require a database schema change, if someone could chime in here that would be great.