### PR TITLE
refactor(tracing)!: rename `HATSU_LOG_LEVEL` to `HATSU_LOG`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+HATSU_LOG = "info,tokio::net=debug"
 HATSU_DATABASE_URL = "sqlite://hatsu.sqlite3"
 HATSU_DOMAIN = "hatsu.local"
 HATSU_LISTEN_HOST = "0.0.0.0"

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -25,7 +25,7 @@ pub fn init() -> Result<(), AppError> {
 fn filter_layer() -> EnvFilter {
     EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
-        .with_env_var("HATSU_LOG_LEVEL")
+        .with_env_var("HATSU_LOG")
         .from_env_lossy()
 }
 

--- a/docs/src/admins/environments.md
+++ b/docs/src/admins/environments.md
@@ -6,6 +6,13 @@ It is required unless it has a suffix (optional).
 
 However, it may exist as a built-in preset (in the source code) or an example preset (in [`.env.example`](https://github.com/importantimport/hatsu/blob/main/.env.example))
 
+## HATSU_LOG
+
+- default: `info`
+- example: `info,tokio::net=debug`
+
+The format is the same as the [`RUST_LOG`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax).
+
 ## HATSU_ENV_FILE
 
 - default: `/etc/hatsu/.env`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `.env.example` to include the new configuration variable `HATSU_LOG`.
  - Added information about `HATSU_LOG` to the admin environment documentation, including its default value and example usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->