### PR TITLE
fix(ci): enable vendored openssl in normal build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ docs/book
 # direnv / devenv
 .direnv
 .devenv
+
+# nix build result
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "hatsu_tracing",
  "hatsu_utils",
  "human-panic",
+ "openssl",
  "sea-orm",
  "snmalloc-rs",
  "tokio",
@@ -2386,6 +2387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,6 +2403,7 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ uuid = { version = "1.8", features = [
 ] }
 
 [dependencies]
-# openssl = { version = "*", features = ["vendored"] }
+openssl = { version = "*", features = ["vendored"] }
 hatsu_api_apub = { workspace = true }
 hatsu_apub = { workspace = true }
 hatsu_backend = { workspace = true }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717535930,
-        "narHash": "sha256-1hZ/txnbd/RmiBPNUs7i8UQw2N89uAK3UzrGAWdnFfU=",
+        "lastModified": 1718474113,
+        "narHash": "sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "55e7754ec31dac78980c8be45f8a28e80e370946",
+        "rev": "0095fd8ea00ae0a9e6014f39c375e40c2fbd3386",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717646450,
-        "narHash": "sha256-KE+UmfSVk5PG8jdKdclPVcMrUB8yVZHbsjo7ZT1Bm3c=",
+        "lastModified": 1718276985,
+        "narHash": "sha256-u1fA0DYQYdeG+5kDm1bOoGcHtX0rtC7qs2YA2N1X++I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "818dbe2f96df233d2041739d6079bb616d3e5597",
+        "rev": "3f84a279f1a6290ce154c5531378acc827836fbb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,11 @@
       perSystem = { config, self', inputs', lib, nixpkgs, pkgs, system, ... }:
         let
           toolchain = with fenix.packages.${system}; combine [
-            # (fromToolchainFile {
-            #   file = ./rust-toolchain.toml;
-            #   sha256 = "bx0H6uahYI+z2i+dMWDH/GzH9mm298NMsUF0eR5kmc4=";
-            # })
-            minimal.toolchain
+            (fromToolchainFile {
+              file = ./rust-toolchain.toml;
+              sha256 = "bx0H6uahYI+z2i+dMWDH/GzH9mm298NMsUF0eR5kmc4=";
+            })
+            # minimal.toolchain
             # targets.aarch64-unknown-linux-gnu.latest.rust-std
             # targets.aarch64-unknown-linux-musl.latest.rust-std
             # targets.x86_64-unknown-linux-gnu.latest.rust-std

--- a/flake.nix
+++ b/flake.nix
@@ -18,13 +18,19 @@
       imports = [ ];
       systems = [ "x86_64-linux" "aarch64-linux" ];
 
-      perSystem = { config, self', inputs', lib, pkgs, system, ... }:
+      perSystem = { config, self', inputs', lib, nixpkgs, pkgs, system, ... }:
         let
-          toolchain = fenix.packages.${system}.fromToolchainFile
-            {
-              file = ./rust-toolchain.toml;
-              sha256 = "bx0H6uahYI+z2i+dMWDH/GzH9mm298NMsUF0eR5kmc4=";
-            };
+          toolchain = with fenix.packages.${system}; combine [
+            # (fromToolchainFile {
+            #   file = ./rust-toolchain.toml;
+            #   sha256 = "bx0H6uahYI+z2i+dMWDH/GzH9mm298NMsUF0eR5kmc4=";
+            # })
+            minimal.toolchain
+            # targets.aarch64-unknown-linux-gnu.latest.rust-std
+            # targets.aarch64-unknown-linux-musl.latest.rust-std
+            # targets.x86_64-unknown-linux-gnu.latest.rust-std
+            # targets.x86_64-unknown-linux-musl.latest.rust-std
+          ];
 
           craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
 

--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,8 @@
             nativeBuildInputs = with pkgs; [ cmake pkg-config ];
             buildInputs = with pkgs; [ openssl ];
 
-            # try fix openssl
-            OPENSSL_DIR = "${pkgs.openssl.dev}";
-            OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
-            OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include/";
+            # fix openssl-sys
+            OPENSSL_NO_VENDOR = true;
           };
 
           cargoArtifacts = craneLib.buildDepsOnly commonArgs;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude nix build results.
  - Uncommented `openssl` dependency in `Cargo.toml`.
  - Modified `flake.nix` to update `nixpkgs` integration and adjust `OPENSSL` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->