### PR TITLE
refactor(utils/data): tips for missing env

### DIFF
--- a/crates/utils/src/data.rs
+++ b/crates/utils/src/data.rs
@@ -34,7 +34,7 @@ impl AppEnv {
             hatsu_listen_port: env::var("HATSU_LISTEN_PORT")
                 .unwrap_or_else(|_| String::from("3939")),
             hatsu_primary_account: env::var("HATSU_PRIMARY_ACCOUNT")
-            .expect("environment variable HATSU_PRIMARY_ACCOUNT not found. see https://hatsu.cli.rs/admins/environments.html#hatsu_primary_account"),
+                .expect("environment variable HATSU_PRIMARY_ACCOUNT not found. see https://hatsu.cli.rs/admins/environments.html#hatsu_primary_account"),
             hatsu_access_token: env::var("HATSU_ACCESS_TOKEN").ok(),
             hatsu_node_name: env::var("HATSU_NODE_NAME").ok(),
             hatsu_node_description: env::var("HATSU_NODE_DESCRIPTION").ok(),

--- a/crates/utils/src/data.rs
+++ b/crates/utils/src/data.rs
@@ -27,12 +27,14 @@ impl AppEnv {
         Ok(Self {
             hatsu_database_url: env::var("HATSU_DATABASE_URL")
                 .unwrap_or_else(|_| String::from("sqlite::memory:")),
-            hatsu_domain: env::var("HATSU_DOMAIN")?,
+            hatsu_domain: env::var("HATSU_DOMAIN")
+                .expect("environment variable HATSU_DOMAIN not found. see https://hatsu.cli.rs/admins/environments.html#hatsu_domain"),
             hatsu_listen_host: env::var("HATSU_LISTEN_HOST")
                 .unwrap_or_else(|_| String::from("127.0.0.1")),
             hatsu_listen_port: env::var("HATSU_LISTEN_PORT")
                 .unwrap_or_else(|_| String::from("3939")),
-            hatsu_primary_account: env::var("HATSU_PRIMARY_ACCOUNT")?,
+            hatsu_primary_account: env::var("HATSU_PRIMARY_ACCOUNT")
+            .expect("environment variable HATSU_PRIMARY_ACCOUNT not found. see https://hatsu.cli.rs/admins/environments.html#hatsu_primary_account"),
             hatsu_access_token: env::var("HATSU_ACCESS_TOKEN").ok(),
             hatsu_node_name: env::var("HATSU_NODE_NAME").ok(),
             hatsu_node_description: env::var("HATSU_NODE_DESCRIPTION").ok(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for missing environment variables `HATSU_DOMAIN` and `HATSU_PRIMARY_ACCOUNT`, providing clearer guidance and links to relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->