### PR TITLE
fix(apub/verify_blocked): check actor instead of id

### DIFF
--- a/crates/apub/src/activities/create_or_update/note.rs
+++ b/crates/apub/src/activities/create_or_update/note.rs
@@ -98,7 +98,7 @@ impl ActivityHandler for CreateOrUpdateNote {
     async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
         // TODO
         ApubPost::verify(&self.object, &self.id, data).await?;
-        verify_blocked(&self.id, data).await?;
+        verify_blocked(&self.actor(), data).await?;
         Ok(())
     }
 

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -61,7 +61,7 @@ impl ActivityHandler for Follow {
 
     async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
         // TODO
-        verify_blocked(&self.id, data).await?;
+        verify_blocked(&self.actor(), data).await?;
         Ok(())
     }
 

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -46,7 +46,7 @@ impl ActivityHandler for UndoFollow {
 
     async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
         // TODO
-        verify_blocked(&self.id, data).await?;
+        verify_blocked(&self.actor(), data).await?;
         Ok(())
     }
 

--- a/crates/apub/src/activities/like_or_announce/like_or_announce.rs
+++ b/crates/apub/src/activities/like_or_announce/like_or_announce.rs
@@ -51,7 +51,7 @@ impl ActivityHandler for LikeOrAnnounce {
 
     async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
         // TODO
-        verify_blocked(&self.id, data).await?;
+        verify_blocked(&self.actor(), data).await?;
         Ok(())
     }
 

--- a/crates/apub/src/activities/like_or_announce/undo_like_or_announce.rs
+++ b/crates/apub/src/activities/like_or_announce/undo_like_or_announce.rs
@@ -39,7 +39,7 @@ impl ActivityHandler for UndoLikeOrAnnounce {
 
     async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
         // TODO
-        verify_blocked(&self.id, data).await?;
+        verify_blocked(&self.actor(), data).await?;
         Ok(())
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced verification logic for user blocking across multiple activities (CreateOrUpdateNote, Follow, UndoFollow, LikeOrAnnounce, UndoLikeOrAnnounce) by utilizing the actor's identity instead of a direct identifier.
  
- **Bug Fixes**
	- Improved accuracy of blocking checks, potentially resolving issues with incorrect blocking status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->