### PR TITLE
chore!: no longer require x86-64-v3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,7 @@
 [rust]
 lld = true
 
-# x86_64-unknown-linux-gnu (lld)
-# [target.x86_64-unknown-linux-gnu]
-# rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
-
-[target.'cfg(all())']
+[build]
 rustflags = [
     # UUID Unstable for Uuid::now_v7()
     # https://docs.rs/uuid/1.4.0/uuid/index.html#unstable-features
@@ -16,12 +12,3 @@ rustflags = [
     "--cfg",
     "tokio_unstable",
 ]
-
-# x86_64-v3 (Intel Haswell / AMD Excavator and above)
-# https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
-[target.'cfg(target_arch = "x86_64")']
-rustflags = ["-C", "target-cpu=x86-64-v3"]
-
-# aarch64 (ARM Neon)
-[target.'cfg(target_arch = "aarch64")']
-rustflags = ["-C", "target-feature=+neon"]

--- a/docs/src/admins/install-binary.md
+++ b/docs/src/admins/install-binary.md
@@ -1,9 +1,5 @@
 # Binary Installation
 
-> Hatsu uses the `x86-64-v3` target architecture for optimal performance.
->
-> If you are using an older processor, you currently need to build locally and change the corresponding values in `.cargo/config.toml`.
-
 ## Releases
 
 You can download both stable and beta versions of Hatsu from the [Releases page](https://github.com/importantimport/hatsu/releases).

--- a/docs/src/admins/install-docker.md
+++ b/docs/src/admins/install-docker.md
@@ -1,9 +1,5 @@
 # Docker Installation
 
-> Hatsu uses the `x86-64-v3` target architecture for optimal performance.
->
-> If you are using an older processor, you currently need to build locally and change the corresponding values in `.cargo/config.toml`.
-
 You can find images on GitHub: [https://github.com/importantimport/hatsu/pkgs/container/hatsu](https://github.com/importantimport/hatsu/pkgs/container/hatsu)
 
 Hatsu uses three primary tags: `latest` (stable), `beta` and `nightly`, literally.

--- a/docs/src/admins/install-nix.md
+++ b/docs/src/admins/install-nix.md
@@ -2,10 +2,6 @@
 
 [![nixpkgs unstable package](https://repology.org/badge/version-for-repo/nix_unstable/hatsu.svg)](https://repology.org/project/hatsu/versions)
 
-> Hatsu uses the `x86-64-v3` target architecture for optimal performance.
->
-> If you are using an older processor, you currently need to build locally and change the corresponding values in `.cargo/config.toml`.
-
 Hatsu is available in Nixpkgs, NUR and Flakes.
 
 macOS (Darwin) is not supported.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined `[build]` section in the configuration for improved project requirements.
  
- **Documentation**
	- Updated installation guides to clarify the target architecture (`x86-64-v3`) for optimal performance.
	- Added instructions for users with older processors regarding local builds and configuration adjustments for binary and Docker installations.
	- Removed outdated notes from the Nix installation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->