### PR TITLE
fix(user/followers): return actor url

### DIFF
--- a/crates/api_apub/src/users/user_followers.rs
+++ b/crates/api_apub/src/users/user_followers.rs
@@ -78,7 +78,7 @@ pub async fn handler(
                             .fetch_page(page - 1)
                             .await?
                             .into_iter()
-                            .map(|follow| Url::parse(&follow.id))
+                            .map(|follow| Url::parse(&follow.actor))
                             .filter_map(Result::ok)
                             .map(serde_json::to_value)
                             .filter_map(Result::ok)


### PR DESCRIPTION
First up, I'm not sure what the ActivityPub spec says.
But using the "id" used by hatsu in the followers collection does seem strange to me. At least all the "URLs" in the collection lead to a 404 page. It seems using the actual "actor" (follower) URL is better? At least a tool like https://browser.pub seems to deal better with that. (See e.g. https://browser.pub/https://blog.uvokchee.de).

What do you think?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved user follower URL generation mechanism to ensure accurate mapping of follower information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->